### PR TITLE
Update to elixir 1.4

### DIFF
--- a/lib/red_black_tree.ex
+++ b/lib/red_black_tree.ex
@@ -620,17 +620,6 @@ defimpl Enumerable, for: RedBlackTree do
   def reduce(tree, acc, fun), do: RedBlackTree.reduce(tree, acc, fun)
 end
 
-defimpl Access, for: RedBlackTree do
-  def get(tree, key) do
-    RedBlackTree.get(tree, key)
-  end
-
-  def get_and_update(tree, key, fun) do
-    {get, update} = fun.(RedBlackTree.get(tree, key))
-    {get, RedBlackTree.insert(tree, key, update)}
-  end
-end
-
 defimpl Collectable, for: RedBlackTree do
   def into(original) do
     {original, fn

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule RedBlackTree.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
-     package: package]
+     deps: deps(),
+     package: package()]
   end
 
   def application do

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "0.1.17"},
-  "ex_doc": {:hex, :ex_doc, "0.7.3"}}
+%{"earmark": {:hex, :earmark, "0.1.17", "a2269e72ff85501bdb58c2de9edc0a9a17a4be2757883eed1f601b30494ed2bf", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.7.3", "8f52bfbfcbc0206dd08dd94aae86a3fd5330ba2f37c73cfea2918ed4c96d1769", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]}}

--- a/test/red_black_tree_test.exs
+++ b/test/red_black_tree_test.exs
@@ -1,9 +1,7 @@
 defmodule RedBlackTreeTest do
   use ExUnit.Case, async: true
   alias RedBlackTree.Node
-  doctest Dict
   doctest RedBlackTree
-  defp dict_impl, do: RedBlackTree
 
   test "initializing a red black tree" do
     assert %RedBlackTree{} == RedBlackTree.new


### PR DESCRIPTION
* Changed Access from Protocol to a Behavior (as 1.4 requires)
* Fixed up some syntax warnings
* Removed deprecated `Dict` related code. 

Existing tests continue to pass.