### PR TITLE
Allow :order to be passed into `to_list`

### DIFF
--- a/lib/red_black_tree.ex
+++ b/lib/red_black_tree.ex
@@ -225,10 +225,21 @@ defmodule RedBlackTree do
     %RedBlackTree{tree | root: do_balance(root)}
   end
 
-  def to_list(%RedBlackTree{}=tree) do
-    reduce_nodes(tree, [], fn (node, members) ->
-      [{node.key, node.value} | members]
-    end) |> Enum.reverse
+  @doc """
+  Converts a `%RedBlackTree{}` to a list.
+
+  Options available:
+  - `:order` - available options are `:in_order`, `:pre_order`, or `:post_order`
+    Defaults to `:in_order` if no order is given.
+  """
+  def to_list(%RedBlackTree{}=tree, opts \\ []) do
+    opts
+    |> Keyword.get(:order, :in_order)
+    |> reduce_nodes(tree, [],
+      fn (node, members) ->
+        [{node.key, node.value} | members]
+      end)
+    |> Enum.reverse
   end
 
   ## Helpers


### PR DESCRIPTION
The `reduce_nodes` function allows for an order to be specified, and
`to_list` calls this function but does not allow you to specify the
order that you would like. Here, we allow for a keyword list in
idiomatic elixir style that has an `:order` option.

Ideally, I would like `reduce_nodes` and so also `to_list` to provide
an explanation about the order options - what they mean, etc.

However, that seems beyond the scope of this PR.